### PR TITLE
Fixed: /usr/lib/steam/steam: line 104: tar: command not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN sudo sed -i '/#\[multilib\]/,/#Include = \/etc\/pacman.d\/mirrorlist/ s/#//'
 
 # used by steam.sh
 USER root
-RUN pacman --noconfirm -S util-linux file gawk diffutils pciutils
+RUN pacman --noconfirm -S util-linux file gawk diffutils pciutils tar
 
 # cleanup
 RUN rm -rf \


### PR DESCRIPTION
Current version of steam launcher failed on docker run:
```
/usr/lib/steam/steam: line 104: tar: command not found
Failed to extract /usr/lib/steam/bootstraplinux_ubuntu12_32.tar.xz, aborting installation.
```